### PR TITLE
Owner_id column removed from cats table

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ CREATE TABLE cats (
 id INTEGER PRIMARY KEY, 
 name TEXT, 
 age INTEGER,
-owner_id INTEGER, breed TEXT);
+breed TEXT);
 
 CREATE TABLE owners (id INTEGER PRIMARY KEY, name TEXT);
 


### PR DESCRIPTION
The new cats table created on line 99 does not have the owner_id column referenced on line 150. The join-table relationship example does not require a foreign key in the cats table.